### PR TITLE
fix: email link

### DIFF
--- a/English_Documentation/TRON_Introduction/Community.md
+++ b/English_Documentation/TRON_Introduction/Community.md
@@ -40,7 +40,7 @@ TRON Foundation open to the community
 [CoinMarketCap](https://coinmarketcap.com/currencies/tron/)  
 [Github](https://github.com/tronprotocol)  
 [Telegram](https://t.me/tronnetworkEN)  
-[E-mail](service@tron.network)
+[E-mail](mailto:service@tron.network)
 
 Other community platforms for international usership.
 


### PR DESCRIPTION
The existing email URL was inaccurate and redirected users to a 404 error page. This PR rectifies the URL, ensuring users are directed to the appropriate destination.